### PR TITLE
Added 8.0 to available iOS sdks. Fixed iPhoneSimulator SDK paths finder mechanism.

### DIFF
--- a/clang-as-ios-dylib.py
+++ b/clang-as-ios-dylib.py
@@ -102,7 +102,7 @@ def get_args_without_osxims():
 def get_iphonesimulator_sdk_versions_for_arch(developer_dir, arch):
     sdk_paths = glob.glob(os.path.join(
         developer_dir,
-        'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator*.sdk'))
+        'Platforms/iPhoneSimulator.platform/Developer/SDKs/iPhoneSimulator*.*.sdk'))
     sdk_paths.sort()
     sdk_names = [os.path.basename(sdk_path) for sdk_path in sdk_paths]
     sdk_versions = [
@@ -145,6 +145,7 @@ def get_args_for_iphonesimulator_platform(developer_dir, sdk_version, deployment
     new_args.extend([
         '-isysroot', isysroot,
         '-F%s/Developer/Library/Frameworks' % isysroot,
+        '-F%s/../../Library/Frameworks' % isysroot,
         '-mios-simulator-version-min=%s' % deployment_target,
         ])
     return new_args

--- a/generate-links.py
+++ b/generate-links.py
@@ -15,6 +15,7 @@ versions = [
     '6.1',
     '7.0',
     '7.1',
+    '8.0',
     # Symbolic names for the earliest and latest SDK versions that support the
     # current arch.
     'earliest',

--- a/links/cc-iphonesimulator-5.0-targeting-8.0
+++ b/links/cc-iphonesimulator-5.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-5.1-targeting-8.0
+++ b/links/cc-iphonesimulator-5.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-6.0-targeting-8.0
+++ b/links/cc-iphonesimulator-6.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-6.1-targeting-8.0
+++ b/links/cc-iphonesimulator-6.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-7.0-targeting-8.0
+++ b/links/cc-iphonesimulator-7.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-7.1-targeting-8.0
+++ b/links/cc-iphonesimulator-7.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-5.0
+++ b/links/cc-iphonesimulator-8.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-5.1
+++ b/links/cc-iphonesimulator-8.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-6.0
+++ b/links/cc-iphonesimulator-8.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-6.1
+++ b/links/cc-iphonesimulator-8.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-7.0
+++ b/links/cc-iphonesimulator-8.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-7.1
+++ b/links/cc-iphonesimulator-8.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-8.0
+++ b/links/cc-iphonesimulator-8.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-earliest
+++ b/links/cc-iphonesimulator-8.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-8.0-targeting-latest
+++ b/links/cc-iphonesimulator-8.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-earliest-targeting-8.0
+++ b/links/cc-iphonesimulator-earliest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/cc-iphonesimulator-latest-targeting-8.0
+++ b/links/cc-iphonesimulator-latest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-5.0-targeting-8.0
+++ b/links/ld-iphonesimulator-5.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-5.1-targeting-8.0
+++ b/links/ld-iphonesimulator-5.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-6.0-targeting-8.0
+++ b/links/ld-iphonesimulator-6.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-6.1-targeting-8.0
+++ b/links/ld-iphonesimulator-6.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-7.0-targeting-8.0
+++ b/links/ld-iphonesimulator-7.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-7.1-targeting-8.0
+++ b/links/ld-iphonesimulator-7.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-5.0
+++ b/links/ld-iphonesimulator-8.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-5.1
+++ b/links/ld-iphonesimulator-8.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-6.0
+++ b/links/ld-iphonesimulator-8.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-6.1
+++ b/links/ld-iphonesimulator-8.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-7.0
+++ b/links/ld-iphonesimulator-8.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-7.1
+++ b/links/ld-iphonesimulator-8.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-8.0
+++ b/links/ld-iphonesimulator-8.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-earliest
+++ b/links/ld-iphonesimulator-8.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-8.0-targeting-latest
+++ b/links/ld-iphonesimulator-8.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-earliest-targeting-8.0
+++ b/links/ld-iphonesimulator-earliest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/ld-iphonesimulator-latest-targeting-8.0
+++ b/links/ld-iphonesimulator-latest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py


### PR DESCRIPTION
In Xcode 6 beta 6+ there was added new folder in `Platforms/iPhoneSimulator.platform/Developer/SDKs/`  `iPhoneSimulator.sdk` which contains latest available iPhone Simulator SDK. But also there is `iPhoneSimulator<latest iOS version>.sdk`. Thereby script could ignore `iPhoneSimulator.sdk` to fix exception (it is supposed that path contains sdk version) and to not lose any information (required folder still exists).
