### PR TITLE
Prefix links with clang name for cpp support

### DIFF
--- a/clang-as-ios-dylib.py
+++ b/clang-as-ios-dylib.py
@@ -158,14 +158,14 @@ def parse_sdk_version_and_deployment_target_from_script_name(
     sdk_version_label = None
     deployment_target_label = None
 
-    pattern = re.compile(r'^(?:(clang(?:\+\+)?)-)?(cc|ld)-iphonesimulator-(.*?)-targeting-(.*?)$')
+    pattern = re.compile(r'^(?:(?P<clang_name>clang(?:\+\+)?)-)?(?P<tool>cc|ld)-iphonesimulator-(?P<sdk>.*?)-targeting-(?P<target>.*?)$')
     match = pattern.match(script_name)
 
     if match:
-        clang_name = match.group(1) or 'clang'
-        tool = match.group(2)
-        sdk_version_label = match.group(3)
-        deployment_target_label = match.group(4)
+        clang_name = match.group('clang_name') or 'clang'
+        tool = match.group('tool')
+        sdk_version_label = match.group('sdk')
+        deployment_target_label = match.group('target')
     else:
         raise Exception(
             'script_name was not formatted as '

--- a/generate-links.py
+++ b/generate-links.py
@@ -24,13 +24,15 @@ versions = [
 
 for sdk_version in versions:
     for deployment_target in versions:
-        for tool in ['cc', 'ld']:
-            name = 'links/%s-iphonesimulator-%s-targeting-%s' % (
-                tool, sdk_version, deployment_target)
+        # Empty string for backwards compatibility
+        for clang_name_prefix in ['', 'clang-', 'clang++-']:
+            for tool in ['cc', 'ld']:
+                name = 'links/%s%s-iphonesimulator-%s-targeting-%s' % (
+                    clang_name_prefix, tool, sdk_version, deployment_target)
 
-            if os.path.exists(name):
-                print '%s (exists)' % name
-            else:
-                print '%s (creating)' % name
-                os.symlink('../clang-as-ios-dylib.py', name)
+                if os.path.exists(name):
+                    print '%s (exists)' % name
+                else:
+                    print '%s (creating)' % name
+                    os.symlink('../clang-as-ios-dylib.py', name)
 

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.0-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-5.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-5.1-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-5.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.0-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-6.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-6.1-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-6.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.0-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-7.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-7.1-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-7.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-8.0-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-8.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-earliest-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-earliest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-5.0
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-5.1
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-6.0
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-6.1
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-7.0
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-7.1
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-8.0
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-earliest
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-cc-iphonesimulator-latest-targeting-latest
+++ b/links/clang++-cc-iphonesimulator-latest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.0-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-5.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-5.1-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-5.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.0-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-6.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-6.1-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-6.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.0-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-7.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-7.1-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-7.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-8.0-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-8.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-earliest-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-earliest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-5.0
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-5.1
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-6.0
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-6.1
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-7.0
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-7.1
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-8.0
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-earliest
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang++-ld-iphonesimulator-latest-targeting-latest
+++ b/links/clang++-ld-iphonesimulator-latest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.0-targeting-latest
+++ b/links/clang-cc-iphonesimulator-5.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-5.1-targeting-latest
+++ b/links/clang-cc-iphonesimulator-5.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.0-targeting-latest
+++ b/links/clang-cc-iphonesimulator-6.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-6.1-targeting-latest
+++ b/links/clang-cc-iphonesimulator-6.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.0-targeting-latest
+++ b/links/clang-cc-iphonesimulator-7.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-7.1-targeting-latest
+++ b/links/clang-cc-iphonesimulator-7.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-8.0-targeting-latest
+++ b/links/clang-cc-iphonesimulator-8.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-earliest-targeting-latest
+++ b/links/clang-cc-iphonesimulator-earliest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-5.0
+++ b/links/clang-cc-iphonesimulator-latest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-5.1
+++ b/links/clang-cc-iphonesimulator-latest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-6.0
+++ b/links/clang-cc-iphonesimulator-latest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-6.1
+++ b/links/clang-cc-iphonesimulator-latest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-7.0
+++ b/links/clang-cc-iphonesimulator-latest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-7.1
+++ b/links/clang-cc-iphonesimulator-latest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-8.0
+++ b/links/clang-cc-iphonesimulator-latest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-earliest
+++ b/links/clang-cc-iphonesimulator-latest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-cc-iphonesimulator-latest-targeting-latest
+++ b/links/clang-cc-iphonesimulator-latest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.0-targeting-latest
+++ b/links/clang-ld-iphonesimulator-5.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-5.1-targeting-latest
+++ b/links/clang-ld-iphonesimulator-5.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.0-targeting-latest
+++ b/links/clang-ld-iphonesimulator-6.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-6.1-targeting-latest
+++ b/links/clang-ld-iphonesimulator-6.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.0-targeting-latest
+++ b/links/clang-ld-iphonesimulator-7.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-7.1-targeting-latest
+++ b/links/clang-ld-iphonesimulator-7.1-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-8.0-targeting-latest
+++ b/links/clang-ld-iphonesimulator-8.0-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-earliest-targeting-latest
+++ b/links/clang-ld-iphonesimulator-earliest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-5.0
+++ b/links/clang-ld-iphonesimulator-latest-targeting-5.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-5.1
+++ b/links/clang-ld-iphonesimulator-latest-targeting-5.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-6.0
+++ b/links/clang-ld-iphonesimulator-latest-targeting-6.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-6.1
+++ b/links/clang-ld-iphonesimulator-latest-targeting-6.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-7.0
+++ b/links/clang-ld-iphonesimulator-latest-targeting-7.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-7.1
+++ b/links/clang-ld-iphonesimulator-latest-targeting-7.1
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-8.0
+++ b/links/clang-ld-iphonesimulator-latest-targeting-8.0
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-earliest
+++ b/links/clang-ld-iphonesimulator-latest-targeting-earliest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py

--- a/links/clang-ld-iphonesimulator-latest-targeting-latest
+++ b/links/clang-ld-iphonesimulator-latest-targeting-latest
@@ -1,0 +1,1 @@
+../clang-as-ios-dylib.py


### PR DESCRIPTION
When compiling cpp files, we need to call into clang++ instead of clang. This adds new symlinks that prefix 'clang-' and 'clang++-'. The python file then examines its path to determine whether it needs to invoke clang or clang++. It preserves backwards compatibility by making the clang- or clang++- prefix optional.

Tested by deleting clang-as-ios-dylib in xctool, symlinking my updates to the deleted path, and building + testing xctool.
